### PR TITLE
Change JSON link to open in new tab

### DIFF
--- a/src/components/Show.js
+++ b/src/components/Show.js
@@ -98,8 +98,8 @@ class Show extends Component {
                                     <tr key={ping.key} className={ping.changed ? 'item-highlight' : ''}>
                                         <td>{ping.displayDate}</td>
                                         <td>{ping.pingType}</td>
-                                        <td><a target="_blank" href={this.jsonToDataURI(ping.payload)}>Raw JSON</a></td>
-                                        <td class="text-monospace">{TruncateString(ping.payload, 150)}</td>
+                                        <td><a target="_blank" rel="noopener noreferrer" href={this.jsonToDataURI(ping.payload)}>Raw JSON</a></td>
+                                        <td class="text-monospace">{TruncateString(ping.payload, 150)}&hellip;</td>
                                     </tr>
                                 )}
                             </tbody>


### PR DESCRIPTION
Following up to #9, this opens the raw JSON in a new tab, rendered with the Firefox JSON viewer.
Also moves the 'raw json' link further to the front to make it more accessible.

What do you think arkadiusz?