### PR TITLE
Show validation errors in client view

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -37,8 +37,12 @@ firebase deploy --only functions
 PubSub subscriptions are needed to consume pings from the pipeline. For production project run:
 ```
 gcloud pubsub subscriptions create decoded-debug-to-debugview --topic projects/moz-fx-data-shar-nonprod-efed/topics/structured-decoded-debug --push-endpoint "https://us-central1-debug-ping-preview.cloudfunctions.net/debugPing/"
+
+gcloud pubsub subscriptions create structured-errors-to-debugview --topic projects/moz-fx-data-shar-nonprod-efed/topics/structured-error --push-endpoint "https://us-central1-debug-ping-preview.cloudfunctions.net/decoderError/"
 ```
 For dev:
 ```
 gcloud pubsub subscriptions create decoded-debug-to-debugview --topic projects/moz-fx-data-shar-nonprod-efed/topics/structured-decoded-debug --push-endpoint "https://us-central1-glean-debug-view-dev-237806.cloudfunctions.net/debugPing/"
+
+gcloud pubsub subscriptions create structured-errors-to-debugview --topic projects/moz-fx-data-shar-nonprod-efed/topics/structured-error --push-endpoint "https://us-central1-glean-debug-view-dev-237806.cloudfunctions.net/decoderError/"
 ```

--- a/src/components/Show.js
+++ b/src/components/Show.js
@@ -31,7 +31,7 @@ class Show extends Component {
 
         querySnapshot.docChanges().forEach((change) => {
             if (change.type === "added") {
-                const { addedAt, payload, pingType } = change.doc.data();
+                const { addedAt, payload, pingType, error, errorType, errorMessage } = change.doc.data();
                 pings.unshift({
                     key: change.doc.id,
                     addedAt: addedAt,
@@ -39,6 +39,9 @@ class Show extends Component {
                     payload: payload,
                     pingType: pingType,
                     changed: true,
+                    error: error,
+                    errorType: errorType,
+                    errorMessage: errorMessage,
                 });
             }
             if (change.type === "removed") {
@@ -97,7 +100,7 @@ class Show extends Component {
                                 <td>{ping.displayDate}</td>
                                 <td>{ping.pingType}</td>
                                 <td><a target="_blank" rel="noopener noreferrer" href={this.jsonToDataURI(ping.payload)}>Raw JSON</a></td>
-                                <td class="text-monospace">{TruncateString(ping.payload, 150)}&hellip;</td>
+                                <td className={(ping.error ? 'text-danger ' : '') + 'text-monospace'}>{ping.error ? ping.errorType + ' ' + ping.errorMessage : TruncateString(ping.payload, 150)}&hellip;</td>
                             </tr>
                         )}
                     </tbody>


### PR DESCRIPTION
Viewing errors seems to be useful for client developers (#5). We can  consume error messages from `decoded-error` topic and store them together with ping documents (with some additional, error-specific fields).

I propose to show errors in the client view, together with pings, colored red for clarity:
![screenshot](https://screenshotscdn.firefoxusercontent.com/images/8ea64375-b0ac-4b6f-ba62-5e706b68d517.png)

Dev instance with this change applied:
https://glean-debug-view-dev-237806.firebaseapp.com/pings/6ff20eb7-e80d-4452-b45f-2ea7e63547aa/test-debug-id
