### PR TITLE
Normalize font sizes on all screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,15 +74,65 @@ table {
   user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
 
+p {
+  font-size: 1.25vw;
+}
+
+span {
+  font-size: 1.25vw;
+}
+
+li {
+  font-size: 1.25vw;
+}
+
 th {
   font-size: medium;
-  font-size: 1.1vw;
+  font-size: 1.5vw;
 }
 
 td {
   font-size: medium;
-  font-size: 1vw;
+  font-size: 1.25vw;
   vertical-align: top;
+}
+
+pre {
+  font-size: 1.25vw;
+}
+
+.btn-sm {
+  font-size: 0.95vw;
+}
+
+@media screen and (min-width: 1200px) {
+  p {
+    font-size: 14px;
+  }
+
+  span {
+    font-size: 14px;
+  }
+
+  li {
+    font-size: 14px;
+  }
+
+  td {
+    font-size: 14px;
+  }
+
+  th {
+    font-size: 16px;
+  }
+
+  pre {
+    font-size: 14px;
+  }
+
+  .btn-sm {
+    font-size: 12px;
+  }
 }
 
 .div-icon {

--- a/src/components/ActiveClients.js
+++ b/src/components/ActiveClients.js
@@ -96,7 +96,6 @@ const ActiveClients = () => {
             </li>
           </ul>
         </div>
-        <br />
         <h4>Active Debug Tags ({displayDebugTags().length})</h4>
         <SearchBar
           onInput={(input) => setSearch(input)}

--- a/src/components/DebugTagPings/components/DebugTagPingsComponent.js
+++ b/src/components/DebugTagPings/components/DebugTagPingsComponent.js
@@ -166,7 +166,6 @@ const DebugTagPings = ({ debugId }) => {
           </li>
         </ul>
       </div>
-      <br />
       <h4>
         Recent pings for: <b>{debugId}</b> ({displayPings.length})
       </h4>
@@ -204,7 +203,6 @@ const DebugTagPings = ({ debugId }) => {
                 <br />
                 <button
                   className='btn btn-sm btn-outline-secondary'
-                  style={{ fontSize: '0.75vw' }}
                   onClick={handleCopyPayload(ping.key, ping.payload)}
                 >
                   {!!copySuccessKey && copySuccessKey === ping.key ? 'Copied!' : 'Copy Payload'}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -11,7 +11,7 @@ import HelpIcon from './Icons/HelpIcon';
 
 const NavBar = ({ authenticated, theme, themeToggler }) => {
   return (
-    <nav className='navbar navbar-expand-md' style={{ marginBottom: 30 }}>
+    <nav className='navbar navbar-expand-md' style={{ marginBottom: 10 }}>
       <Link to='/' className='text-decoration-none'>
         <h3 className='m-0'>Glean Debug Ping Viewer</h3>
       </Link>


### PR DESCRIPTION
Makes fonts on smaller screens bigger but adds a max font-size for each element to avoid fonts getting too large. Some of the screenshots make it seem like it is harder to read than it is if you view them on a really small screen, but the display is better on large monitors.

**Full ultrawide**
![Screen Shot 2022-11-23 at 9 16 22 AM](https://user-images.githubusercontent.com/24759139/203569232-b9451040-4bd7-4e44-9db2-21fd2743667c.png)


**Half ultrawide**
![Screen Shot 2022-11-23 at 9 16 39 AM](https://user-images.githubusercontent.com/24759139/203569263-b73469af-7035-401f-b772-b48344f9b4cd.png)

**Laptop screen**
<img width="1512" alt="Screen Shot 2022-11-23 at 9 16 54 AM" src="https://user-images.githubusercontent.com/24759139/203569319-de38dfec-5dc4-4435-9e7b-8487ed3f70ab.png">

**Half laptop**
<img width="756" alt="Screen Shot 2022-11-23 at 9 17 04 AM" src="https://user-images.githubusercontent.com/24759139/203569377-8480ce1a-32f4-4b09-b7e8-48a4a40b0c24.png">
