### PR TITLE
Remove timeout from scrollTo

### DIFF
--- a/src/components/ShowRawPing/components/ShowRawPing.js
+++ b/src/components/ShowRawPing/components/ShowRawPing.js
@@ -1,3 +1,5 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
 import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { doc, getDoc, getFirestore } from 'firebase/firestore';


### PR DESCRIPTION
This fixes the sluggish feeling part of #57 

There are 2 scenarios
1. Ping is not loaded yet - we ignore and then scroll once it is loaded.
2. Ping is already loaded - we call scroll function with 0 delay.

https://user-images.githubusercontent.com/24759139/205076656-9e5076ad-9545-4c6b-b1b9-8f529de1ff64.mov

