### PR TITLE
Only show event timeline if there are multiple events

### DIFF
--- a/src/components/Events/index.js
+++ b/src/components/Events/index.js
@@ -80,7 +80,8 @@ const Events = ({ events }) => {
           </li>
         </ul>
         <p style={{ textAlign: 'center' }}>
-          Selected Range: <strong>{minSliderValue}</strong> - <strong>{maxSliderValue}</strong>
+          Selected Range (in milliseconds): <strong>{minSliderValue}</strong> -{' '}
+          <strong>{maxSliderValue}</strong>
           <br />
           Events in current range: <strong>{getCountOfEventsInCurrentRange()}</strong>
           <br />


### PR DESCRIPTION
If there is a single event, we don't want to show the timeline. But, we always want to show the event table. Now we perform event array length checks before rendering both the timeline and the table.



1 event

<img width="1402" alt="single-event" src="https://user-images.githubusercontent.com/24759139/208137197-5f5d76ce-4c90-450a-be63-4ba06a16d4f6.png">


multiple events
<img width="1400" alt="multiple-events" src="https://user-images.githubusercontent.com/24759139/208137180-b418b428-8874-4256-b7e5-6c9b2e889c50.png">

