### PR TITLE
Redirect to / if user is already logged in

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,7 +73,7 @@ const App = () => {
             path='/help'
             element={<SecuredRoute component={Help} authenticated={authenticated} />}
           />
-          <Route path='/login' element={<SignInScreen />} />
+          <Route path='/login' element={<SignInScreen authenticated={authenticated} />} />
         </Routes>
       </div>
     </ThemeProvider>

--- a/src/components/SignInScreen.js
+++ b/src/components/SignInScreen.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import { Navigate } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
 import { GoogleAuthProvider } from 'firebase/auth';
 
@@ -12,13 +15,30 @@ const uiConfig = {
   signInOptions: [GoogleAuthProvider.PROVIDER_ID]
 };
 
-const SignInScreen = () => {
+const SignInScreen = ({ authenticated }) => {
+  // If we are already signed in, we want to redirect to the home page
+  // so we don't get into the bad loop where you signed in and `/login`
+  // won't redirect you.
   return (
-    <div>
-      <p className='text-center'>Please sign-in:</p>
-      <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />
-    </div>
+    <>
+      {authenticated ? (
+        <Navigate
+          to={{
+            pathname: '/'
+          }}
+        />
+      ) : (
+        <div>
+          <p className='text-center'>Please sign-in:</p>
+          <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth} />
+        </div>
+      )}
+    </>
   );
+};
+
+SignInScreen.propTypes = {
+  authenticated: PropTypes.bool.isRequired
 };
 
 export default SignInScreen;


### PR DESCRIPTION
Fix the issue of being dropped onto the `/login` page while already signed in and seeming like you are going through an infinite loop of google authentication.

I ran into this flow after the first deployment because I screwed up my auth. This should not be something our users run into, but just in the off case that they ever get directed to this page and they are signed in, we want them to be sent back to the main page instead.