### PR TITLE
#67: Remove react-show-more-text dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,22 +1057,6 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.19.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.19.4.tgz",
@@ -11340,15 +11324,6 @@
             }
           }
         }
-      }
-    },
-    "react-show-more-text": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/react-show-more-text/-/react-show-more-text-1.6.2.tgz",
-      "integrity": "sha512-Z6tRcnEosHvo07vZw36LxCjqYq4ghgaDI273b5XcayJ1PYbT56OKbaQlPqH7W9LGF5rhUVIhEDBPURuG5eO/Uw==",
-      "requires": {
-        "@babel/polyfill": "^7.12.1",
-        "prop-types": "^15.7.2"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "react-plotly.js": "^2.6.0",
     "react-router-dom": "^6.4.2",
     "react-scripts": "^5.0.1",
-    "react-show-more-text": "^1.6.2",
     "styled-components": "^5.3.6",
     "use-react-router-breadcrumbs": "^4.0.1"
   },

--- a/src/components/DebugTagPings/components/ErrorField.js
+++ b/src/components/DebugTagPings/components/ErrorField.js
@@ -43,9 +43,7 @@ const ErrorField = ({ ping }) => {
 
   return (
     <td className='text-danger text-monospace error'>
-      <ReadMore lines={3}>
-        <p className='cell-overflow'>{errorText}</p>
-      </ReadMore>
+      <ReadMore numberOfLines={3} text={errorText} />
       {infoIcon}
     </td>
   );

--- a/src/components/DebugTagPings/components/PayloadField.js
+++ b/src/components/DebugTagPings/components/PayloadField.js
@@ -8,11 +8,7 @@ const PayloadField = ({ pingPayload }) => {
   pingPayload = pingPayload.replace(/":"/g, '": "');
   pingPayload = pingPayload.replace(/","/g, '", "');
 
-  return (
-    <ReadMore lines={3}>
-      <p className='cell-overflow'>{pingPayload}</p>
-    </ReadMore>
-  );
+  return <ReadMore numberOfLines={3} text={pingPayload} />;
 };
 
 PayloadField.propTypes = {

--- a/src/components/Events/index.js
+++ b/src/components/Events/index.js
@@ -80,9 +80,7 @@ const Events = ({ events }) => {
                   </td>
                   <td className='event-timestamp align-middle'>{timestamp}</td>
                   <td className='event-extras align-middle'>
-                    <ReadMore lines={3}>
-                      <p className='cell-overflow'>{JSON.stringify(extra)}</p>
-                    </ReadMore>
+                    <ReadMore numberOfLines={3} text={JSON.stringify(extra)} />
                   </td>
                 </tr>
               );

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -1,33 +1,31 @@
-import React from 'react';
-import ShowMoreText from 'react-show-more-text';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-const ReadMore = ({ lines, less, more, children }) => {
+const ReadMore = ({ numberOfLines = 3, text }) => {
+  const [show, setShow] = useState(false);
   return (
     <div>
-      <ShowMoreText
-        lines={lines}
-        more={more}
-        less={less}
-        truncatedEndingComponent={'…'}
-        anchorClass='btn btn-sm btn-outline-secondary'
+      <button onClick={() => setShow((prev) => !prev)} className='btn btn-sm btn-outline-secondary'>
+        {show ? 'collapse' : 'expand'}
+      </button>
+      <div
+        style={{
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+          WebkitLineClamp: show ? 'unset' : numberOfLines,
+          display: '-webkit-box',
+          WebkitBoxOrient: 'vertical'
+        }}
       >
-        {children}
-      </ShowMoreText>
+        {text}
+      </div>
     </div>
   );
 };
 
-ReadMore.defaultProps = {
-  lines: 3,
-  more: 'expand',
-  less: 'collapse'
-};
-
 ReadMore.propTypes = {
-  lines: PropTypes.number.isRequired,
-  less: PropTypes.string,
-  more: PropTypes.string
+  numberOfLines: PropTypes.number.isRequired,
+  text: PropTypes.string.isRequired
 };
 
 export default ReadMore;


### PR DESCRIPTION
`react-show-more-text` was causing perf issues doing too many calculations at once on the pings page. It is more performant to build our own show more component using just CSS.

Addresses #67 

**New**
https://user-images.githubusercontent.com/24759139/212199482-26844563-cd99-4a16-9339-d9e2e55ac6f1.mov


**Old**

https://user-images.githubusercontent.com/24759139/212199595-7773141d-4b5c-48fd-b16a-271eadf3aacd.mov

