### PR TITLE
#70 - Reapply filters when pings is updated

### DIFF
--- a/src/components/DebugTagPings/components/Filter.js
+++ b/src/components/DebugTagPings/components/Filter.js
@@ -78,7 +78,7 @@ const Filter = ({ pings, handleFilter, handleFiltersApplied }) => {
     // whenever one of our filter options update.
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [search, pingType, metricType, metricId]);
+  }, [pings, search, pingType, metricType, metricId]);
 
   /// render ///
   const pingTypes = aggregatePingTypes(pings);


### PR DESCRIPTION
Closes #70 

Add `pings` to the dependency array of the `useEffect` that applies the filters. This means when our `pings` array updates because a new ping comes in, it will tell the `useEffect` to run again and the correct filtering is applied.

**Filter**

https://user-images.githubusercontent.com/24759139/213901741-973bdbb3-6c81-4914-b1ae-db2e13743e27.mov




**Search**

https://user-images.githubusercontent.com/24759139/213901746-e0f5ba78-9bab-4180-9314-e2a8a5f352af.mov


