### PR TITLE
Bug 1852552: Allow users to enable/disable telemetry

### DIFF
--- a/src/components/SecuredRoute.js
+++ b/src/components/SecuredRoute.js
@@ -7,9 +7,11 @@
 import React from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { updateTelemetry } from '../lib/telemetry';
 
 const SecuredRoute = ({ component: Component, authenticated }) => {
   const params = useParams();
+  updateTelemetry();
 
   return authenticated ? (
     <Component {...params} />

--- a/src/components/SecuredRoute.js
+++ b/src/components/SecuredRoute.js
@@ -7,11 +7,11 @@
 import React from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { updateTelemetry } from '../lib/telemetry';
+import { updateTelemetryClientUploadStatus } from '../lib/telemetry';
 
 const SecuredRoute = ({ component: Component, authenticated }) => {
   const params = useParams();
-  updateTelemetry();
+  updateTelemetryClientUploadStatus();
 
   return authenticated ? (
     <Component {...params} />

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,9 @@ import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import { initTelemetry } from './lib/telemetry';
+import { initTelemetryClient } from './lib/telemetry';
 
-initTelemetry();
+initTelemetryClient();
 
 ReactDOM.render(
     <Router>

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,9 @@ import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import Glean from '@mozilla/glean/web';
+import { initTelemetry } from './lib/telemetry';
 
-// Initialize Glean. ToDo: Replace uploadEnabled: false with a user preference
-const APP_NAME = "debug-ping-view"
-Glean.initialize(APP_NAME, false, { maxEvents: 1 });
+initTelemetry();
 
 ReactDOM.render(
     <Router>

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import Glean from '@mozilla/glean/web';
+
+const APP_NAME = "debug-ping-view";
+const APP_TELEMETRY_PREFERENCE_STORAGE_KEY = "telemetryEnabled";
+
+function isTelemetryEnabled() {
+  return navigator.doNotTrack !== "1";
+}
+
+function setAppTelemetryPreferenceInStorage(telemetryPreferenceValue) {
+    sessionStorage.setItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY, telemetryPreferenceValue)
+}
+
+function getAppTelemetryPreferenceFromStorage() {
+  return sessionStorage.getItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY);
+}
+
+// Initialize Glean.
+export function initTelemetry() {
+  const telemetryEnabled = isTelemetryEnabled();
+  setAppTelemetryPreferenceInStorage(telemetryEnabled.toString());
+  Glean.initialize(APP_NAME, telemetryEnabled, { maxEvents: 1 });
+}
+
+// Update Glean upload settings if user's consent to telemetry changes
+export function updateTelemetry() {
+  const appTelemetryPreference = getAppTelemetryPreferenceFromStorage();
+  const telemetryEnabled = isTelemetryEnabled();
+  if (appTelemetryPreference !== telemetryEnabled.toString()) {
+    setAppTelemetryPreferenceInStorage(telemetryEnabled.toString())
+    Glean.setUploadEnabled(telemetryEnabled)
+  }
+}

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -6,34 +6,56 @@
 
 import Glean from '@mozilla/glean/web';
 
-const APP_NAME = "debug-ping-view";
-const APP_TELEMETRY_PREFERENCE_STORAGE_KEY = "telemetryEnabled";
+const APP_NAME = 'debug-ping-view';
+const APP_TELEMETRY_PREFERENCE_STORAGE_KEY = 'telemetryEnabled';
 
+/**
+ * Check browser's `navigator.doNotTrack` property to determine the
+ * telemetry preference i.e. whether telemetry can be collected or not.
+ *
+ * @returns {boolean} true if telemetry can be collected, else false.
+ */
 function isTelemetryEnabled() {
-  return navigator.doNotTrack !== "1";
+  return navigator.doNotTrack !== '1';
 }
 
+/**
+ * Set the current telemetry preference in `window.sessionStorage` object.
+ *
+ * @param {string} telemetryPreferenceValue a string (either 'true' or 'false')
+ *                                          representing telemetry preference
+ */
 function setAppTelemetryPreferenceInStorage(telemetryPreferenceValue) {
-    sessionStorage.setItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY, telemetryPreferenceValue)
+  sessionStorage.setItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY, telemetryPreferenceValue);
 }
 
+/**
+ * Get the current telemetry preference from `window.sessionStorage` object.
+ *
+ * @returns {string} a string (either 'true' or 'false')
+ */
 function getAppTelemetryPreferenceFromStorage() {
   return sessionStorage.getItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY);
 }
 
-// Initialize Glean.
-export function initTelemetry() {
+/**
+ * Initialize telemetry client, setting it's upload status based on the current
+ * telemetry preference.
+ */
+export function initTelemetryClient() {
   const telemetryEnabled = isTelemetryEnabled();
   setAppTelemetryPreferenceInStorage(telemetryEnabled.toString());
   Glean.initialize(APP_NAME, telemetryEnabled, { maxEvents: 1 });
 }
 
-// Update Glean upload settings if user's consent to telemetry changes
-export function updateTelemetry() {
+/**
+ * Update telemetry client's upload status if telemetry preference changed.
+ */
+export function updateTelemetryClientUploadStatus() {
   const appTelemetryPreference = getAppTelemetryPreferenceFromStorage();
   const telemetryEnabled = isTelemetryEnabled();
   if (appTelemetryPreference !== telemetryEnabled.toString()) {
-    setAppTelemetryPreferenceInStorage(telemetryEnabled.toString())
-    Glean.setUploadEnabled(telemetryEnabled)
+    setAppTelemetryPreferenceInStorage(telemetryEnabled.toString());
+    Glean.setUploadEnabled(telemetryEnabled);
   }
 }

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -7,7 +7,6 @@
 import Glean from '@mozilla/glean/web';
 
 const APP_NAME = 'debug-ping-view';
-const APP_TELEMETRY_PREFERENCE_STORAGE_KEY = 'telemetryEnabled';
 
 /**
  * Check browser's `navigator.doNotTrack` property to determine the
@@ -20,42 +19,16 @@ function isTelemetryEnabled() {
 }
 
 /**
- * Set the current telemetry preference in `window.sessionStorage` object.
- *
- * @param {string} telemetryPreferenceValue a string (either 'true' or 'false')
- *                                          representing telemetry preference
- */
-function setAppTelemetryPreferenceInStorage(telemetryPreferenceValue) {
-  sessionStorage.setItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY, telemetryPreferenceValue);
-}
-
-/**
- * Get the current telemetry preference from `window.sessionStorage` object.
- *
- * @returns {string} a string (either 'true' or 'false')
- */
-function getAppTelemetryPreferenceFromStorage() {
-  return sessionStorage.getItem(APP_TELEMETRY_PREFERENCE_STORAGE_KEY);
-}
-
-/**
  * Initialize telemetry client, setting it's upload status based on the current
  * telemetry preference.
  */
 export function initTelemetryClient() {
-  const telemetryEnabled = isTelemetryEnabled();
-  setAppTelemetryPreferenceInStorage(telemetryEnabled.toString());
-  Glean.initialize(APP_NAME, telemetryEnabled, { maxEvents: 1 });
+  Glean.initialize(APP_NAME, isTelemetryEnabled(), { maxEvents: 1 });
 }
 
 /**
- * Update telemetry client's upload status if telemetry preference changed.
+ * Update telemetry client's upload status.
  */
 export function updateTelemetryClientUploadStatus() {
-  const appTelemetryPreference = getAppTelemetryPreferenceFromStorage();
-  const telemetryEnabled = isTelemetryEnabled();
-  if (appTelemetryPreference !== telemetryEnabled.toString()) {
-    setAppTelemetryPreferenceInStorage(telemetryEnabled.toString());
-    Glean.setUploadEnabled(telemetryEnabled);
-  }
+  Glean.setUploadEnabled(isTelemetryEnabled());
 }


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1852552

- Using `navigator.doNotTrack` property to disable/enable collecting metrics via glean