### PR TITLE
Bug 1852553: Record more click events on pages via glean.js 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.venv
+src/glean/generated
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -9,12 +9,13 @@ import { Link } from 'react-router-dom';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
 
 import { isUuid } from '../lib/isUuid';
+import { recordClick } from '../lib/telemetry';
 
 const Breadcrumbs = () => {
   const breadcrumbs = useBreadcrumbs();
 
   return (
-    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }}>
+    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} onClick={() => {recordClick('Breadcrumbs')}}>
       {breadcrumbs.map(({ breadcrumb, key, location, match }) => {
         // `/pings` is included in the routes, but there is not a /pings page,
         // so we can hide it from our breadcrumbs.

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -15,6 +15,7 @@ import BugIcon from './Icons/BugIcon';
 import SignOutIcon from './Icons/SignOut';
 import HelpIcon from './Icons/HelpIcon';
 import Breadcrumbs from './Breadcrumbs';
+import { recordClick } from '../lib/telemetry';
 
 const NavBar = ({ authenticated, theme, themeToggler }) => {
   return (
@@ -31,7 +32,7 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
             >
               <div></div>
               <div className='navbar-nav' role='presentation'>
-                <div className='nav-item nav-link cursor-pointer'>
+                <div className='nav-item nav-link cursor-pointer' onClick={() => {recordClick('Theme toggler')}}>
                   <ThemeToggle theme={theme} toggleTheme={themeToggler} />
                 </div>
                 <div className='nav-item nav-link cursor-pointer'>
@@ -40,12 +41,13 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                     target='_blank'
                     rel='noopener noreferrer'
                     style={{ all: 'unset ' }}
+                    onClick={() => {recordClick('Bug')}}
                   >
                     <BugIcon />
                   </a>
                 </div>
                 <div className='nav-item nav-link cursor-pointer'>
-                  <Link to={`/help`} style={{ all: 'unset' }}>
+                  <Link to={`/help`} style={{ all: 'unset' }} onClick={() => {recordClick('Help')}}>
                     <HelpIcon />
                   </Link>
                 </div>
@@ -53,6 +55,7 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                   className='nav-item nav-link cursor-pointer'
                   type='btn btn-lg '
                   onClick={() => {
+                    recordClick('Sign out');
                     auth.signOut();
                   }}
                 >

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -6,6 +6,7 @@
 
 import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import { recordClick } from '../lib/telemetry';
 
 const ReadMore = ({ numberOfLines = 3, text }) => {
   const [show, setShow] = useState(false);
@@ -22,7 +23,11 @@ const ReadMore = ({ numberOfLines = 3, text }) => {
   }, [text]);
 
   return (
-    <div className='cursor-pointer' onClick={() => setShow((prev) => !prev)}>
+    <div className='cursor-pointer' onClick={
+      () => {
+        recordClick('Payload expand on Pings page');
+        setShow((prev) => !prev)}}
+    >
       <span
         style={{
           textOverflow: 'ellipsis',

--- a/src/components/ShowRawPing/components/PingSection.js
+++ b/src/components/ShowRawPing/components/PingSection.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 
 import { flattenJson } from '../../../lib/flattenJson';
 import { getNestedAndNonNestedKeysFromObject } from '../lib';
+import { recordClick } from '../../../lib/telemetry';
 
 const PingSection = ({ pingSection, header, isNested }) => {
   // If the component was called recursively (isNested), then we show a smaller
@@ -90,7 +91,7 @@ const PingSection = ({ pingSection, header, isNested }) => {
     <>
       {isNested ? (
         <details>
-          <summary>{renderTitle()}</summary>
+          <summary onClick={() => {recordClick('PingData.summary')}}>{renderTitle()}</summary>
           {renderTable()}
         </details>
       ) : (

--- a/src/components/ShowRawPing/components/ShowRawPing.js
+++ b/src/components/ShowRawPing/components/ShowRawPing.js
@@ -18,7 +18,7 @@ import PingSection from './PingSection';
 import ReturnToTop from '../../ReturnToTop';
 
 import { calculateDaysRemainingForPing } from '../../../lib/date';
-import { recordLoad } from '../../../lib/telemetry';
+import { recordClick, recordLoad } from '../../../lib/telemetry';
 
 const ShowRawPing = ({ docId }) => {
   const { hash, key, pathname } = useLocation();
@@ -131,6 +131,7 @@ const ShowRawPing = ({ docId }) => {
   };
 
   const handleLineNumberClick = (lineNumber) => (e) => {
+    recordClick('Line number click');
     lineNumber = `L${lineNumber}`;
 
     let startLine;


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1852553

- Adds the click events mentioned in https://github.com/mozilla/debug-ping-view/pull/86#pullrequestreview-1633372567
- Adds `.venv` and `src/glean/generated` folder to `.gitignore` file