### PR TITLE
Issue 89 - remove expandable/collapsible ping headers

### DIFF
--- a/src/components/Events/index.js
+++ b/src/components/Events/index.js
@@ -13,7 +13,6 @@ import Timeline from './components/Timeline';
 import { aggregateCountOfEventProperty } from './lib';
 
 import './styles.css';
-import { recordClick } from '../../lib/telemetry';
 
 const Events = ({ events }) => {
   const trimmedEvents = useMemo(() => {
@@ -104,25 +103,21 @@ const Events = ({ events }) => {
   const showTable = !!trimmedEvents.length;
   return (
     <div>
-      <details>
-        <summary onClick={() => {recordClick('PingData.events')}}>
-          <h4>events</h4>
-        </summary>
-        {events.length > 500 && (
-          <p>
-            <strong>Only the first 500 events are displayed.</strong>
-          </p>
-        )}
+      <h4>events</h4>
+      {events.length > 500 && (
         <p>
-          Number of events: <strong>{trimmedEvents.length}</strong>
+          <strong>Only the first 500 events are displayed.</strong>
         </p>
+      )}
+      <p>
+        Number of events: <strong>{trimmedEvents.length}</strong>
+      </p>
 
-        <h5>Aggregate Counts</h5>
-        {renderKeyValueCountTable('name')}
-        {renderKeyValueCountTable('category')}
-        {showTimeline && renderTimeline()}
-        {showTable && renderEventTable()}
-      </details>
+      <h5>Aggregate Counts</h5>
+      {renderKeyValueCountTable('name')}
+      {renderKeyValueCountTable('category')}
+      {showTimeline && renderTimeline()}
+      {showTable && renderEventTable()}
     </div>
   );
 };

--- a/src/components/Metrics/index.js
+++ b/src/components/Metrics/index.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import BarChart from './components/BarChart';
 import Histogram from './components/Histogram';
 import MetricValuesTable from './components/MetricValuesTable';
-import { recordClick } from '../../lib/telemetry';
 
 const Metrics = ({ metrics }) => {
   /// helpers ///
@@ -49,14 +48,12 @@ const Metrics = ({ metrics }) => {
     }
 
     return (
-      <details key={metricKey} onClick={() => {recordClick('PingData.metrics')}}>
-        <summary>
-          <p>
-            <strong>{metricKey}</strong>
-          </p>
-        </summary>
+      <div key={metricKey}>
+        <p>
+          <strong>{metricKey}</strong>
+        </p>
         {content}
-      </details>
+      </div>
     );
   };
 

--- a/src/components/ShowRawPing/components/PingSection.js
+++ b/src/components/ShowRawPing/components/PingSection.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 
 import { flattenJson } from '../../../lib/flattenJson';
 import { getNestedAndNonNestedKeysFromObject } from '../lib';
-import { recordClick } from '../../../lib/telemetry';
 
 const PingSection = ({ pingSection, header, isNested }) => {
   // If the component was called recursively (isNested), then we show a smaller
@@ -89,17 +88,8 @@ const PingSection = ({ pingSection, header, isNested }) => {
 
   return (
     <>
-      {isNested ? (
-        <details>
-          <summary onClick={() => {recordClick('PingData.summary')}}>{renderTitle()}</summary>
-          {renderTable()}
-        </details>
-      ) : (
-        <>
-          {renderTitle()}
-          {renderTable()}
-        </>
-      )}
+      {renderTitle()}
+      {renderTable()}
     </>
   );
 };

--- a/src/components/ShowRawPing/components/ShowRawPing.js
+++ b/src/components/ShowRawPing/components/ShowRawPing.js
@@ -178,9 +178,6 @@ const ShowRawPing = ({ docId }) => {
           <li>
             <strong>Share</strong> this link with others to directly access this ping.
           </li>
-          <li>
-            <strong>Click</strong> on a ping header to see the nested ping data.
-          </li>
         </ul>
       </div>
       <PingSection pingSection={JSON.parse(ping)} header={'Ping Data'} />

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -54,10 +54,6 @@ export const GlobalStyles = createGlobalStyle`
     background-color: ${({ theme }) => theme.rawPingActiveLineBackground};
   }
 
-  summary::before {
-    filter: invert(${({ theme }) => theme.invert});
-  }
-
   .btn {
     color: ${({ theme }) => theme.text};
   }


### PR DESCRIPTION
**changelog**
- always show ping data on raw pings page
- remove all `summary`/`details` elements
- remove instruction note about clicking on ping headers
- remove unnecessary global style for `summary`

**demo**

https://github.com/mozilla/debug-ping-view/assets/24759139/08516cac-ab7f-4c9d-815e-6a58dc795df3



