### PR TITLE
gleanjs v2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,9 +2430,9 @@
       "integrity": "sha512-22dS5UA4ASMmaMBYVUr/EsuyVOVPjhzizYOvuYWVhzKPYGCTHeQt5uA735KR7unXbstr6xbe7tB2uAg2xjYJvg=="
     },
     "@mozilla/glean": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.1.tgz",
-      "integrity": "sha512-qPD5Je/ercCCUlFJnfs0T3+zNvU/IhP/SpLMaHiOwdF4RwuNC+eoCPzLIOjkDm1LnZwlAzd9qnyoqTPoAAmIpg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
+      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@mozilla-protocol/core": "^16.0.1",
-    "@mozilla/glean": "^2.0.1",
+    "@mozilla/glean": "^2.0.5",
     "firebase": "^9.12.1",
     "moment": "^2.29.4",
     "plotly.js": "^2.16.3",


### PR DESCRIPTION
Bump `@mozilla/glean` dependency to the latest version.