### PR TITLE
Bump gleanjs dependency to latest prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@mozilla-protocol/core": "^16.0.1",
-    "@mozilla/glean": "^2.0.5",
+    "@mozilla/glean": "^3.0.0-pre.0",
     "firebase": "^9.12.1",
     "moment": "^2.29.4",
     "plotly.js": "^2.16.3",


### PR DESCRIPTION
 - Using gleanjs 3.0.0-pre.0 now