### PR TITLE
Handle JSON parsing errors when displaying ping data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,9 +2430,9 @@
       "integrity": "sha512-22dS5UA4ASMmaMBYVUr/EsuyVOVPjhzizYOvuYWVhzKPYGCTHeQt5uA735KR7unXbstr6xbe7tB2uAg2xjYJvg=="
     },
     "@mozilla/glean": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
-      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
+      "version": "3.0.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-3.0.0-pre.0.tgz",
+      "integrity": "sha512-abP7eO4eIHpQl3VdTNM28TzdR5mx4uEXu9Vj2iTMEciKAR4uAwajwRfbzD0VB3CVziSqC0LXb93nOkvwAa4GeA==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/src/components/EventStream.js
+++ b/src/components/EventStream.js
@@ -114,20 +114,24 @@ const EventStream = ({ debugId }) => {
     let allEvents = [];
     pings.forEach((ping) => {
       if (ping.payload) {
-        const parsedPing = JSON.parse(ping.payload);
-        const pingEvents = parsedPing.events;
-
-        if (pingEvents) {
-          pingEvents.forEach((pingEvent) => {
-            const startTime = parsedPing.ping_info.start_time;
-            const newDate = new Date(startTime);
-            const dateAsMs = newDate.getTime();
-            const adjustedTimeAsMs = dateAsMs + pingEvent.timestamp;
-            allEvents.push({
-              ...pingEvent,
-              timestamp: adjustedTimeAsMs
+        try {
+          const parsedPing = JSON.parse(ping.payload);
+          const pingEvents = parsedPing.events;
+  
+          if (pingEvents) {
+            pingEvents.forEach((pingEvent) => {
+              const startTime = parsedPing.ping_info.start_time;
+              const newDate = new Date(startTime);
+              const dateAsMs = newDate.getTime();
+              const adjustedTimeAsMs = dateAsMs + pingEvent.timestamp;
+              allEvents.push({
+                ...pingEvent,
+                timestamp: adjustedTimeAsMs
+              });
             });
-          });
+          }
+        } catch (e) {
+          console.log(e);
         }
       }
     });


### PR DESCRIPTION
Wrap all ping `JSON.parse` calls in `try-catch` blocks.

Whenever we can't parse a ping, we need to show an error message.

Current example URL: http://localhost:3000/pings/bedrock/6fc41f1b-c199-4c4c-b409-265067a55124

### Updated error UI
<img width="1495" alt="Screenshot 2023-11-14 at 9 32 56 AM" src="https://github.com/mozilla/debug-ping-view/assets/24759139/cfe9f36f-78bb-4c5c-aeb1-ce9916c24703">
