### PR TITLE
Add getpocket to firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,12 +2,12 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /clients/{clientId} {
       allow read, create, update: if request.auth != null
-                                  && (request.auth.token.email.matches('.*@mozilla[.]com') || request.auth.token.email.matches('.*@mozillafoundation[.]org'));
+                                  && (request.auth.token.email.matches('.*@mozilla[.]com') || request.auth.token.email.matches('.*@mozillafoundation[.]org') || request.auth.token.email.matches('.*@getpocket[.]com'));
     }
 
     match /pings/{pingId} {
       allow read, create: if request.auth != null
-                          && (request.auth.token.email.matches('.*@mozilla[.]com') || request.auth.token.email.matches('.*@mozillafoundation[.]org'));
+                          && (request.auth.token.email.matches('.*@mozilla[.]com') || request.auth.token.email.matches('.*@mozillafoundation[.]org') || request.auth.token.email.matches('.*@getpocket[.]com'));
     }
   }
 }


### PR DESCRIPTION
There are currently a few users who previously had `getpocket.com` emails that were migrated over to `mozilla.com` emails. They are having trouble accessing debug ping viewer data in production. They are able to sign in via SSO, but the authentication rules doesn't allow them to read/write any data. We are guessing it may have something to do with firebase auth pulling something old from SSO and the token it receives actually including the getpocket email address.

This fix adds the `getpocket` domain as an email address with the same permissions as the moco and mofo emails.
