### PR TITLE
Add missing title prop for create page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -79,7 +79,7 @@ const App = () => {
           />
           <Route
             path='/create'
-            element={<SecuredRoute component={Create} authenticated={authenticated} />}
+            element={<SecuredRoute component={Create} authenticated={authenticated} title='Create' />}
           />
           <Route
             path='/pings/:debugId'


### PR DESCRIPTION
The `/create` route never got a new title for Telemetry so it is throwing a browser console error. Adding this required `title` prop fixes that.