### PR TITLE
Record clicks via glean's builtin element click recording feature

### DIFF
--- a/src/components/ActiveClients.js
+++ b/src/components/ActiveClients.js
@@ -7,7 +7,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { collection, getFirestore, onSnapshot, orderBy, query } from 'firebase/firestore';
-import GleanMetrics from '@mozilla/glean/metrics';
 
 import ReturnToTop from './ReturnToTop';
 import SearchBar from './SearchBar';
@@ -143,17 +142,16 @@ const ActiveClients = () => {
                     <Link
                       className='text-decoration-none'
                       to={`/pings/${debugId}`}
+                      data-glean-label='Debug ID Pings'
                       onClick={() => {
                         recordClick("Debug ID Pings");
-                        GleanMetrics.recordElementClick({'label': 'Debug ID Pings'});
                       }}
                     >
                       Pings
                     </Link>
                     <br />
-                    <Link className='text-decoration-none' to={`/stream/${debugId}`} onClick={() => {
+                    <Link className='text-decoration-none' to={`/stream/${debugId}`} data-glean-label='Debug ID Event Stream' onClick={() => {
                       recordClick("Debug ID Event Stream")
-                      GleanMetrics.recordElementClick({'label': 'Debug ID Event Stream'});
                     }}>
                       Event Stream
                     </Link>

--- a/src/components/ActiveClients.js
+++ b/src/components/ActiveClients.js
@@ -7,6 +7,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { collection, getFirestore, onSnapshot, orderBy, query } from 'firebase/firestore';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import ReturnToTop from './ReturnToTop';
 import SearchBar from './SearchBar';
@@ -144,6 +145,7 @@ const ActiveClients = () => {
                       to={`/pings/${debugId}`}
                       onClick={() => {
                         recordClick("Debug ID Pings");
+                        GleanMetrics.recordElementClick({'label': 'Debug ID Pings'});
                       }}
                     >
                       Pings
@@ -151,6 +153,7 @@ const ActiveClients = () => {
                     <br />
                     <Link className='text-decoration-none' to={`/stream/${debugId}`} onClick={() => {
                       recordClick("Debug ID Event Stream")
+                      GleanMetrics.recordElementClick({'label': 'Debug ID Event Stream'});
                     }}>
                       Event Stream
                     </Link>

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
-//import GleanMetrics from '@mozilla/glean/metrics';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import { isUuid } from '../lib/isUuid';
 import { recordClick } from '../lib/telemetry';
@@ -16,9 +16,9 @@ const Breadcrumbs = () => {
   const breadcrumbs = useBreadcrumbs();
 
   return (
-    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} data-glean-label='Breadcrumbs' onClick={() => {
+    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} onClick={() => {
       recordClick('Breadcrumbs');
-      //GleanMetrics.recordElementClick({'label': 'Breadcrumbs'});
+      GleanMetrics.recordElementClick({'label': 'Breadcrumbs'});
       }}>
       {breadcrumbs.map(({ breadcrumb, key, location, match }) => {
         // `/pings` & `/stream` are included in the routes, but they don't have

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
-import GleanMetrics from '@mozilla/glean/metrics';
+//import GleanMetrics from '@mozilla/glean/metrics';
 
 import { isUuid } from '../lib/isUuid';
 import { recordClick } from '../lib/telemetry';
@@ -16,9 +16,9 @@ const Breadcrumbs = () => {
   const breadcrumbs = useBreadcrumbs();
 
   return (
-    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} onClick={() => {
+    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} data-glean-label='Breadcrumbs' onClick={() => {
       recordClick('Breadcrumbs');
-      GleanMetrics.recordElementClick({'label': 'Breadcrumbs'});
+      //GleanMetrics.recordElementClick({'label': 'Breadcrumbs'});
       }}>
       {breadcrumbs.map(({ breadcrumb, key, location, match }) => {
         // `/pings` & `/stream` are included in the routes, but they don't have

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import { isUuid } from '../lib/isUuid';
 import { recordClick } from '../lib/telemetry';
@@ -15,7 +16,10 @@ const Breadcrumbs = () => {
   const breadcrumbs = useBreadcrumbs();
 
   return (
-    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} onClick={() => {recordClick('Breadcrumbs')}}>
+    <div style={{ marginLeft: '0.5rem', paddingLeft: 16, marginBottom: 15 }} onClick={() => {
+      recordClick('Breadcrumbs');
+      GleanMetrics.recordElementClick({'label': 'Breadcrumbs'});
+      }}>
       {breadcrumbs.map(({ breadcrumb, key, location, match }) => {
         // `/pings` & `/stream` are included in the routes, but they don't have
         // their own pages, so we can hide it from our breadcrumbs.

--- a/src/components/DebugTagPings/components/DebugTagPingsComponent.js
+++ b/src/components/DebugTagPings/components/DebugTagPingsComponent.js
@@ -16,7 +16,6 @@ import {
   where
 } from 'firebase/firestore';
 import PropTypes from 'prop-types';
-import GleanMetrics from '@mozilla/glean/metrics';
 
 import Filter from './Filter';
 import ErrorField from './ErrorField';
@@ -44,7 +43,6 @@ const DebugTagPings = ({ debugId }) => {
   // Copies the beautified JSON payload to the clipboard.
   const handleCopyPayload = (key, payload, buttonLabel) => () => {
     recordClick(buttonLabel);
-    GleanMetrics.recordElementClick({'label': buttonLabel});
 
     try {
       const beautifiedJson = JSON.stringify(JSON.parse(payload), undefined, 2);
@@ -223,20 +221,19 @@ const DebugTagPings = ({ debugId }) => {
               </td>
               {!!numberOfErrors && <ErrorField ping={ping} />}
               <td className='actions'>
-                <Link to={`/pings/${debugId}/${ping.key}`} onClick={() => {
+                <Link to={`/pings/${debugId}/${ping.key}`} data-glean-label='Details' onClick={() => {
                   recordClick('Details');
-                  GleanMetrics.recordElementClick({'label': 'Details'});
                 }}>Details</Link>
                 <br />
-                <a target='_blank' rel='noopener noreferrer' href={jsonToDataURI(ping.payload)} onClick={() => {
+                <a target='_blank' rel='noopener noreferrer' href={jsonToDataURI(ping.payload)} data-glean-label='Raw JSON' onClick={() => {
                   recordClick('Raw JSON');
-                  GleanMetrics.recordElementClick({'label': 'Raw JSON'});
                   }}>
                   Raw JSON
                 </a>
                 <br />
                 <button
                   className='btn btn-sm btn-outline-secondary'
+                  data-glean-label='Copy Payload'
                   onClick={handleCopyPayload(ping.key, ping.payload, 'Copy Payload')}
                 >
                   {!!copySuccessKey && copySuccessKey === ping.key ? 'Copied!' : 'Copy Payload'}

--- a/src/components/DebugTagPings/components/DebugTagPingsComponent.js
+++ b/src/components/DebugTagPings/components/DebugTagPingsComponent.js
@@ -16,6 +16,7 @@ import {
   where
 } from 'firebase/firestore';
 import PropTypes from 'prop-types';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import Filter from './Filter';
 import ErrorField from './ErrorField';
@@ -43,6 +44,7 @@ const DebugTagPings = ({ debugId }) => {
   // Copies the beautified JSON payload to the clipboard.
   const handleCopyPayload = (key, payload, buttonLabel) => () => {
     recordClick(buttonLabel);
+    GleanMetrics.recordElementClick({'label': buttonLabel});
 
     try {
       const beautifiedJson = JSON.stringify(JSON.parse(payload), undefined, 2);
@@ -221,9 +223,15 @@ const DebugTagPings = ({ debugId }) => {
               </td>
               {!!numberOfErrors && <ErrorField ping={ping} />}
               <td className='actions'>
-                <Link to={`/pings/${debugId}/${ping.key}`} onClick={() => {recordClick('Details')}}>Details</Link>
+                <Link to={`/pings/${debugId}/${ping.key}`} onClick={() => {
+                  recordClick('Details');
+                  GleanMetrics.recordElementClick({'label': 'Details'});
+                }}>Details</Link>
                 <br />
-                <a target='_blank' rel='noopener noreferrer' href={jsonToDataURI(ping.payload)} onClick={() => {recordClick('Raw JSON')}}>
+                <a target='_blank' rel='noopener noreferrer' href={jsonToDataURI(ping.payload)} onClick={() => {
+                  recordClick('Raw JSON');
+                  GleanMetrics.recordElementClick({'label': 'Raw JSON'});
+                  }}>
                   Raw JSON
                 </a>
                 <br />

--- a/src/components/DebugTagPings/components/Filter.js
+++ b/src/components/DebugTagPings/components/Filter.js
@@ -6,6 +6,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import Dropdown from '../../Dropdown';
 import SearchBar from '../../SearchBar';
@@ -51,6 +52,7 @@ const Filter = ({ pings, handleFilter, handleFiltersApplied }) => {
 
   const handleToggleRenderOptions = (buttonLabel) => {
     recordClick(buttonLabel);
+    GleanMetrics.recordElementClick({'label': buttonLabel});
     setShowOptions((prev) => !prev);
   };
 

--- a/src/components/DebugTagPings/components/Filter.js
+++ b/src/components/DebugTagPings/components/Filter.js
@@ -6,7 +6,6 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import GleanMetrics from '@mozilla/glean/metrics';
 
 import Dropdown from '../../Dropdown';
 import SearchBar from '../../SearchBar';
@@ -52,7 +51,6 @@ const Filter = ({ pings, handleFilter, handleFiltersApplied }) => {
 
   const handleToggleRenderOptions = (buttonLabel) => {
     recordClick(buttonLabel);
-    GleanMetrics.recordElementClick({'label': buttonLabel});
     setShowOptions((prev) => !prev);
   };
 
@@ -107,6 +105,7 @@ const Filter = ({ pings, handleFilter, handleFiltersApplied }) => {
       {!showOptions && (
         <button
           type='button'
+          data-glean-label='Add Filters'
           onClick={() => {handleToggleRenderOptions('Add Filters')}}
           className='btn btn-sm btn-outline-secondary'
         >

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import GleanMetrics from '@mozilla/glean/metrics';
+//import GleanMetrics from '@mozilla/glean/metrics';
 
 import { auth } from '../Firebase';
 
@@ -33,9 +33,9 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
             >
               <div></div>
               <div className='navbar-nav' role='presentation'>
-                <div className='nav-item nav-link cursor-pointer' onClick={() => {
+                <div className='nav-item nav-link cursor-pointer' data-glean-label='Theme' onClick={() => {
                     recordClick('Theme');
-                    GleanMetrics.recordElementClick({'label': 'Theme'});
+                    //GleanMetrics.recordElementClick({'label': 'Theme'});
                   }}>
                   <ThemeToggle theme={theme} toggleTheme={themeToggler} />
                 </div>
@@ -45,18 +45,19 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                     target='_blank'
                     rel='noopener noreferrer'
                     style={{ all: 'unset ' }}
+                    data-glean-label='Bug'
                     onClick={() => {
                       recordClick('Bug');
-                      GleanMetrics.recordElementClick({'label': 'Bug'});
+                      //GleanMetrics.recordElementClick({'label': 'Bug'});
                     }}
                   >
                     <BugIcon />
                   </a>
                 </div>
                 <div className='nav-item nav-link cursor-pointer'>
-                  <Link to={`/help`} style={{ all: 'unset' }} onClick={() => {
+                  <Link to={`/help`} style={{ all: 'unset' }} data-glean-label='Help' onClick={() => {
                     recordClick('Help');
-                    GleanMetrics.recordElementClick({'label': 'Help'});
+                    //GleanMetrics.recordElementClick({'label': 'Help'});
                   }}>
                     <HelpIcon />
                   </Link>
@@ -64,9 +65,10 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                 <div
                   className='nav-item nav-link cursor-pointer'
                   type='btn btn-lg '
+                  data-glean-label='Sign out'
                   onClick={() => {
                     recordClick('Sign out');
-                    GleanMetrics.recordElementClick({'label': 'Sign out'});
+                    //GleanMetrics.recordElementClick({'label': 'Sign out'});
                     auth.signOut();
                   }}
                 >

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-//import GleanMetrics from '@mozilla/glean/metrics';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import { auth } from '../Firebase';
 
@@ -33,9 +33,9 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
             >
               <div></div>
               <div className='navbar-nav' role='presentation'>
-                <div className='nav-item nav-link cursor-pointer' data-glean-label='Theme' onClick={() => {
+                <div className='nav-item nav-link cursor-pointer' onClick={() => {
                     recordClick('Theme');
-                    //GleanMetrics.recordElementClick({'label': 'Theme'});
+                    GleanMetrics.recordElementClick({'label': 'Theme'});
                   }}>
                   <ThemeToggle theme={theme} toggleTheme={themeToggler} />
                 </div>
@@ -45,19 +45,18 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                     target='_blank'
                     rel='noopener noreferrer'
                     style={{ all: 'unset ' }}
-                    data-glean-label='Bug'
                     onClick={() => {
                       recordClick('Bug');
-                      //GleanMetrics.recordElementClick({'label': 'Bug'});
+                      GleanMetrics.recordElementClick({'label': 'Bug'});
                     }}
                   >
                     <BugIcon />
                   </a>
                 </div>
                 <div className='nav-item nav-link cursor-pointer'>
-                  <Link to={`/help`} style={{ all: 'unset' }} data-glean-label='Help' onClick={() => {
+                  <Link to={`/help`} style={{ all: 'unset' }} onClick={() => {
                     recordClick('Help');
-                    //GleanMetrics.recordElementClick({'label': 'Help'});
+                    GleanMetrics.recordElementClick({'label': 'Help'});
                   }}>
                     <HelpIcon />
                   </Link>
@@ -65,10 +64,9 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                 <div
                   className='nav-item nav-link cursor-pointer'
                   type='btn btn-lg '
-                  data-glean-label='Sign out'
                   onClick={() => {
                     recordClick('Sign out');
-                    //GleanMetrics.recordElementClick({'label': 'Sign out'});
+                    GleanMetrics.recordElementClick({'label': 'Sign out'});
                     auth.signOut();
                   }}
                 >

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import { auth } from '../Firebase';
 
@@ -32,7 +33,10 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
             >
               <div></div>
               <div className='navbar-nav' role='presentation'>
-                <div className='nav-item nav-link cursor-pointer' onClick={() => {recordClick('Theme')}}>
+                <div className='nav-item nav-link cursor-pointer' onClick={() => {
+                    recordClick('Theme');
+                    GleanMetrics.recordElementClick({'label': 'Theme'});
+                  }}>
                   <ThemeToggle theme={theme} toggleTheme={themeToggler} />
                 </div>
                 <div className='nav-item nav-link cursor-pointer'>
@@ -41,13 +45,19 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                     target='_blank'
                     rel='noopener noreferrer'
                     style={{ all: 'unset ' }}
-                    onClick={() => {recordClick('Bug')}}
+                    onClick={() => {
+                      recordClick('Bug');
+                      GleanMetrics.recordElementClick({'label': 'Bug'});
+                    }}
                   >
                     <BugIcon />
                   </a>
                 </div>
                 <div className='nav-item nav-link cursor-pointer'>
-                  <Link to={`/help`} style={{ all: 'unset' }} onClick={() => {recordClick('Help')}}>
+                  <Link to={`/help`} style={{ all: 'unset' }} onClick={() => {
+                    recordClick('Help');
+                    GleanMetrics.recordElementClick({'label': 'Help'});
+                  }}>
                     <HelpIcon />
                   </Link>
                 </div>
@@ -56,6 +66,7 @@ const NavBar = ({ authenticated, theme, themeToggler }) => {
                   type='btn btn-lg '
                   onClick={() => {
                     recordClick('Sign out');
+                    GleanMetrics.recordElementClick({'label': 'Sign out'});
                     auth.signOut();
                   }}
                 >

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -6,7 +6,7 @@
 
 import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import GleanMetrics from '@mozilla/glean/metrics';
+//import GleanMetrics from '@mozilla/glean/metrics';
 import { recordClick } from '../lib/telemetry';
 
 const ReadMore = ({ numberOfLines = 3, text }) => {
@@ -24,10 +24,10 @@ const ReadMore = ({ numberOfLines = 3, text }) => {
   }, [text]);
 
   return (
-    <div className='cursor-pointer' onClick={
+    <div className='cursor-pointer' data-glean-label='Expand payload' onClick={
       () => {
         recordClick('Expand payload');
-        GleanMetrics.recordElementClick({'label': 'Expand payload'});
+        //GleanMetrics.recordElementClick({'label': 'Expand payload'});
         setShow((prev) => !prev)}}
     >
       <span

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -6,6 +6,7 @@
 
 import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import GleanMetrics from '@mozilla/glean/metrics';
 import { recordClick } from '../lib/telemetry';
 
 const ReadMore = ({ numberOfLines = 3, text }) => {
@@ -26,6 +27,7 @@ const ReadMore = ({ numberOfLines = 3, text }) => {
     <div className='cursor-pointer' onClick={
       () => {
         recordClick('Expand payload');
+        GleanMetrics.recordElementClick({'label': 'Expand payload'});
         setShow((prev) => !prev)}}
     >
       <span

--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -6,7 +6,7 @@
 
 import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-//import GleanMetrics from '@mozilla/glean/metrics';
+import GleanMetrics from '@mozilla/glean/metrics';
 import { recordClick } from '../lib/telemetry';
 
 const ReadMore = ({ numberOfLines = 3, text }) => {
@@ -24,10 +24,10 @@ const ReadMore = ({ numberOfLines = 3, text }) => {
   }, [text]);
 
   return (
-    <div className='cursor-pointer' data-glean-label='Expand payload' onClick={
+    <div className='cursor-pointer' onClick={
       () => {
         recordClick('Expand payload');
-        //GleanMetrics.recordElementClick({'label': 'Expand payload'});
+        GleanMetrics.recordElementClick({'label': 'Expand payload'});
         setShow((prev) => !prev)}}
     >
       <span

--- a/src/components/ReturnToTop.js
+++ b/src/components/ReturnToTop.js
@@ -5,7 +5,6 @@
  */
 
 import React, { useState } from 'react';
-import GleanMetrics from '@mozilla/glean/metrics';
 import { recordClick } from '../lib/telemetry';
 
 const ReturnToTop = () => {
@@ -24,10 +23,10 @@ const ReturnToTop = () => {
     <button
       className='return-to-top btn btn-sm btn-outline-secondary'
       style={{ display: visible ? 'block' : 'none' }}
+      data-glean-label='Back to top'
       onClick={() => {
         // record this click event
         recordClick('Back to top');
-        GleanMetrics.recordElementClick({'label': 'Back to top'});
         document.body.scrollTop = 0;
         document.documentElement.scrollTop = 0;
       }}

--- a/src/components/ReturnToTop.js
+++ b/src/components/ReturnToTop.js
@@ -5,6 +5,7 @@
  */
 
 import React, { useState } from 'react';
+import GleanMetrics from '@mozilla/glean/metrics';
 import { recordClick } from '../lib/telemetry';
 
 const ReturnToTop = () => {
@@ -26,6 +27,7 @@ const ReturnToTop = () => {
       onClick={() => {
         // record this click event
         recordClick('Back to top');
+        GleanMetrics.recordElementClick({'label': 'Back to top'});
         document.body.scrollTop = 0;
         document.documentElement.scrollTop = 0;
       }}

--- a/src/components/ShowRawPing/components/ShowRawPing.js
+++ b/src/components/ShowRawPing/components/ShowRawPing.js
@@ -10,6 +10,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { doc, getDoc, getFirestore } from 'firebase/firestore';
 import PropTypes from 'prop-types';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 import Events from '../../Events';
 import Loading from '../../Loading';
@@ -162,6 +163,7 @@ const ShowRawPing = ({ docId }) => {
 
   const handleLineNumberClick = (lineNumber) => (e) => {
     recordClick('Line number');
+    GleanMetrics.recordElementClick({'label': 'Line number'});
     lineNumber = `L${lineNumber}`;
 
     let startLine;

--- a/src/components/ShowRawPing/components/ShowRawPing.js
+++ b/src/components/ShowRawPing/components/ShowRawPing.js
@@ -10,7 +10,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { doc, getDoc, getFirestore } from 'firebase/firestore';
 import PropTypes from 'prop-types';
-import GleanMetrics from '@mozilla/glean/metrics';
 
 import Events from '../../Events';
 import Loading from '../../Loading';
@@ -163,7 +162,6 @@ const ShowRawPing = ({ docId }) => {
 
   const handleLineNumberClick = (lineNumber) => (e) => {
     recordClick('Line number');
-    GleanMetrics.recordElementClick({'label': 'Line number'});
     lineNumber = `L${lineNumber}`;
 
     let startLine;
@@ -273,6 +271,7 @@ const ShowRawPing = ({ docId }) => {
                     id={anchorId}
                     className='no-select cursor-pointer line-link'
                     style={{ paddingRight: '8px' }}
+                    data-glean-label='Line number'
                     onClick={handleLineNumberClick(lineNumber)}
                   >
                     {padStringLeft(lineNumber.toString(), maxNumberOfDigits, " ")}

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -35,6 +35,7 @@ export function initTelemetryClient(useSendBeacon=false) {
     maxEvents: 1,
     channel: process.env.REACT_APP_ENV,
     httpClient: useSendBeacon ? BrowserSendBeaconUploader : undefined,
+    enableAutoElementClickEvents: true,
   });
 }
 


### PR DESCRIPTION
This PR adds capability to record element clicks via Glean's builtin element click recording api (in https://github.com/mozilla/glean.js/pull/1848).


Scenarios tested:
1. `GleanMetrics.recordElementClick()` api and
2. automatic element click event recording (setting `data-glean-label` attribute for `Back to top` button)

Steps to test:
1. Running `npm start` on local machine
2. Setting `window.Glean.setLogPings(true)` in console
3. Clicking on various buttons and checking in the console logs that `glean.element_click` ping is sent for each of the button click

**EDIT: We are more interested in testing the automatic click event feature. Changed PR accordingly. See https://github.com/mozilla/debug-ping-view/pull/154#issuecomment-1970892702 for details**