### PR TITLE
[Bug 1875839] Remove app defined page load events

### DIFF
--- a/src/components/ActiveClients.js
+++ b/src/components/ActiveClients.js
@@ -15,7 +15,7 @@ import { PING_LIFETIME } from '../lib/constants';
 import { formatDate } from '../lib/date';
 import { usePrevious } from '../lib/usePrevious';
 import { searchArrayElementPropertiesForSubstring } from '../lib/searchArrayElementPropertiesForSubstring';
-import { recordLoad, recordClick } from '../lib/telemetry';
+import { recordClick } from '../lib/telemetry';
 
 const q = query(collection(getFirestore(), 'clients'), orderBy('lastActive', 'desc'));
 
@@ -74,11 +74,6 @@ const ActiveClients = () => {
       handleSearchUpdate();
     }
   }, [search, prevSearch, handleSearchUpdate]);
-
-  useEffect(() => {
-    // record page load event
-    recordLoad('Home');
-  }, []);
 
   /// render ///
   const displayDebugTags = () => {

--- a/src/components/DebugTagPings/components/DebugTagPingsComponent.js
+++ b/src/components/DebugTagPings/components/DebugTagPingsComponent.js
@@ -24,7 +24,7 @@ import ReturnToTop from '../../ReturnToTop';
 import WarningIcon from './WarningIcon';
 
 import { formatDate } from '../../../lib/date';
-import { recordLoad, recordClick } from '../../../lib/telemetry';
+import { recordClick } from '../../../lib/telemetry';
 
 const DebugTagPings = ({ debugId }) => {
   /// state ///
@@ -115,11 +115,6 @@ const DebugTagPings = ({ debugId }) => {
   }, [pings, changeQueue, isFirstSnapshot]);
 
   /// lifecycle ///
-  useEffect(() => {
-    // record page load event
-    recordLoad('Pings');
-  }, []);
-
   useEffect(() => {
     const pingsQuery = query(
       collection(getFirestore(), 'pings'),

--- a/src/components/Help.js
+++ b/src/components/Help.js
@@ -4,19 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { PING_LIFETIME } from '../lib/constants';
-import { recordLoad } from '../lib/telemetry';
 
 const Help = () => {
-  /// lifecycle ///
-  useEffect(() => {
-    // record page load event
-    recordLoad('Help');
-  }, []);
-
   return (
     <div className='container'>
       <h3>Usage</h3>

--- a/src/components/ShowRawPing/components/ShowRawPing.js
+++ b/src/components/ShowRawPing/components/ShowRawPing.js
@@ -19,7 +19,7 @@ import ReturnToTop from '../../ReturnToTop';
 
 import { padStringLeft } from '../lib';
 import { calculateDaysRemainingForPing } from '../../../lib/date';
-import { recordClick, recordLoad } from '../../../lib/telemetry';
+import { recordClick } from '../../../lib/telemetry';
 
 const ShowRawPing = ({ docId }) => {
   const { hash, key, pathname } = useLocation();
@@ -63,11 +63,6 @@ const ShowRawPing = ({ docId }) => {
   };
 
   /// lifecycle ///
-  useEffect(() => {
-    // record page load event
-    recordLoad('Ping');
-  }, []);
-
   // Load all ping data once `docId` is available.
   useEffect(() => {
     getDoc(doc(getFirestore(), 'pings', docId)).then((doc) => {

--- a/src/glean/metrics.yaml
+++ b/src/glean/metrics.yaml
@@ -17,24 +17,6 @@
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 page:
-  load:
-    type: event
-    description: |
-      An event triggered when a page is loaded.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1851440
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1851456#c5
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - glean-team@mozilla.com
-    expires: never
-    extra_keys:
-      page:
-        description: The page that was loaded, e.g. "Home", "Pings", "Ping", "Help".
-        type: string
-
   click:
     type: event
     description: |

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -6,7 +6,7 @@
 
 import Glean from '@mozilla/glean/web';
 import { BrowserSendBeaconUploader } from "@mozilla/glean/web";
-import { load, click } from '../glean/generated/page';
+import { click } from '../glean/generated/page';
 
 const APP_NAME = 'debug-ping-view';
 
@@ -53,13 +53,4 @@ export function updateTelemetryClientUploadStatus() {
  */
 export function recordClick(buttonLabel) {
   click.record({ button: buttonLabel });
-}
-
-/**
- * Record a page load event via telemetry client.
- *
- * @param {string} pageName Name of the page that was loaded.
- */
-export function recordLoad(pageName) {
-  load.record({ page: pageName });
 }


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1875839

As we are already using glean's builtin page load events, we can safely remove the non-standard (i.e. app defined) page load events.