### PR TITLE
Issue 198: allow filtering by session ID in event timeline

### DIFF
--- a/src/components/EventStream.js
+++ b/src/components/EventStream.js
@@ -124,9 +124,15 @@ const EventStream = ({ debugId }) => {
               const newDate = new Date(startTime);
               const dateAsMs = newDate.getTime();
               const adjustedTimeAsMs = dateAsMs + pingEvent.timestamp;
+
+              let sessionId;
+              if (parsedPing && parsedPing.client_info && parsedPing.client_info.session_id) {
+                sessionId = parsedPing.client_info.session_id;
+              }
               allEvents.push({
                 ...pingEvent,
-                timestamp: adjustedTimeAsMs
+                timestamp: adjustedTimeAsMs,
+                sessionId
               });
             });
           }


### PR DESCRIPTION
Allows the user to filter by session ID in the event timeline. If the property doesn't currently support session IDs, nothing changes.


https://github.com/user-attachments/assets/c76725ab-ff7a-4903-a281-710762be9046



Closes #198 
