### PR TITLE
When flattening don't treat `null` as an object

### DIFF
--- a/src/lib/flattenJson.js
+++ b/src/lib/flattenJson.js
@@ -50,7 +50,7 @@ export const flattenJson = (json) => {
         flatten(value, `${name} [${i.toString()}].`);
         i += 1;
       });
-    } else if (typeof valueToFlatten === 'object') {
+    } else if (valueToFlatten != null && typeof valueToFlatten === 'object') {
       Object.keys(valueToFlatten).forEach((key) => {
         flatten(valueToFlatten[key], name + key + '.');
       });


### PR DESCRIPTION
Despite our best efforts we do allow `null` as a value in e.g. object metrics to be sent.
That previously crashed the frontend as it tried to dive into `null` as if it was an object.
It's not, despite everything `typeof null` wants to tell you. We handle that case explicitly now and just render `null` values as ... nothing.

Fixes #233