### PR TITLE
Bug 2050411 - Handle null values in data without further recursion

### DIFF
--- a/functions/schema/glean.1.schema.json
+++ b/functions/schema/glean.1.schema.json
@@ -155,6 +155,43 @@
           "name": {
             "type": "string"
           },
+          "session": {
+            "additionalProperties": false,
+            "description": "Session metadata attached to this event. Absent for out-of-session events and events from before sessions were introduced.",
+            "properties": {
+              "event_seq": {
+                "description": "Per-session event counter, reset at each new session.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_id": {
+                "description": "The unique UUID for this session.",
+                "type": "string"
+              },
+              "session_sample_rate": {
+                "description": "The sampling rate in effect for this session.",
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              "session_seq": {
+                "description": "Monotonically increasing session counter, persisted across restarts.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "session_start_time": {
+                "description": "Wall-clock timestamp at session start (RFC 3339). Absent on events from before this field was introduced.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "session_id",
+              "session_seq",
+              "event_seq",
+              "session_sample_rate"
+            ],
+            "type": "object"
+          },
           "timestamp": {
             "minimum": 0,
             "type": "integer"
@@ -869,8 +906,8 @@
               },
               "description": "Map of metric identifiers (category.name) to boolean values indicating whether the metric is enabled",
               "propertyNames": {
-                "maxLength": 61,
-                "pattern": "^[a-z_][a-z0-9_]{0,29}(\\.[a-z_][a-z0-9_]{0,29})+$",
+                "maxLength": 111,
+                "pattern": "^[a-z_][a-z0-9_\\.]+$",
                 "type": "string"
               },
               "type": "object"
@@ -886,6 +923,15 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "session_sample_rate": {
+              "description": "Remote override for the session sampling rate (0.0–1.0).",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "type": "object"

--- a/src/components/ShowRawPing/components/PingSection.js
+++ b/src/components/ShowRawPing/components/PingSection.js
@@ -48,6 +48,12 @@ const PingSection = ({ pingSection, header, isNested }) => {
                   value = value.toString();
                 }
 
+                // Have to convert nulls to a fixed string or else nothing
+                // is printed in the table.
+                if (value == null) {
+                  value = "<null>";
+                }
+
                 return (
                   <tr key={key}>
                     <td>{key}</td>

--- a/src/components/ShowRawPing/lib.js
+++ b/src/components/ShowRawPing/lib.js
@@ -22,7 +22,7 @@ export const getNestedAndNonNestedKeysFromObject = (obj) => {
   Object.keys(obj).forEach((key) => {
     const value = obj[key];
 
-    if (typeof value === 'object') {
+    if (typeof value === 'object' && value != null) {
       nestedKeys.push(key);
     } else {
       nonNestedKeys.push(key);
@@ -37,7 +37,7 @@ export const getNestedAndNonNestedKeysFromObject = (obj) => {
 
 /**
  * Pad a string to a specified length with a specified character.
- * 
+ *
  * @param {string} s The original string.
  * @param {number} desiredStringLength How long the string should be after padding.
  * @param {string} padChar The character to pad the string with.


### PR DESCRIPTION
The newly introduced `session_sample_rate` can actually be reported as `null`.
And `null` is an object. But it is not nested. Yet we recursed on it, eventually running out of memory.
We now explicitly handle that and display it as `<null>` (just so we show something).