### PR TITLE
chore: support v2 schemas build ids

### DIFF
--- a/functions/schemaLoader.js
+++ b/functions/schemaLoader.js
@@ -100,7 +100,9 @@ exports.gleanSchemaLoader = functions.pubsub.schedule('*/15 * * * *').onRun(asyn
 
 function extractSchemaInfo(schemasBuildIdLabel) {
   const split = schemasBuildIdLabel.split("_");
-  return {hash: split[1], timestamp: split[0]};
+  const hash = split[split.length - 1];
+  const timestamp = split.length > 1 ? split[0] : hash;
+  return {hash, timestamp};
 }
 
 exports.testables = {

--- a/functions/test/schemaLoader.test.js
+++ b/functions/test/schemaLoader.test.js
@@ -17,5 +17,11 @@ describe('Schema loader', () => {
       let extractedHash = schemaLoader.testables.extractSchemaHash(schemasBuildIdLabel);
       assert.deepEqual(extractedHash, {hash: "a381200", timestamp: "202005050149"})
     });
+
+    it('should handle v2 bare commit SHA labels with no timestamp (SVCSE-4252)', () => {
+      const schemasBuildIdLabel = "a381200";
+      let extractedHash = schemaLoader.testables.extractSchemaHash(schemasBuildIdLabel);
+      assert.deepEqual(extractedHash, {hash: "a381200", timestamp: "a381200"})
+    });
   });
 })


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/SVCSE-4252?focusedCommentId=1498691. bqetl already does this: https://github.com/mozilla/bigquery-etl/blob/b98fec71d2fcffabb6a4ee41527bb435733c2658/bigquery_etl/schema/stable_table_schema.py#L66. Setting the timestamp to the hash for v2 style is my Cunningham's Law solution that assumes the timestamp doesn't matter.